### PR TITLE
FIx to make babel instanbul dependency installable

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/malandrew/browserify-babel-istanbul",
   "dependencies": {
-    "babel-istanbul": "git+ssh://git@github.com:rtsao/babel-istanbul.git",
+    "babel-istanbul": "https://github.com/rtsao/babel-istanbul/tarball/master",
     "minimatch": "^2.0.0",
     "through": "^2.3.4"
   },


### PR DESCRIPTION
When behind a firewall that only allows port 80 and 443, trying to install the module fails.

Using the format

https://github.com/:user-name/:project/tarball/:branch-name

works in every case.