### PR TITLE
Bumped babel-istanbul to 0.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/malandrew/browserify-babel-istanbul",
   "dependencies": {
-    "babel-istanbul": "^0.3.20",
+    "babel-istanbul": "^0.5.9",
     "minimatch": "^2.0.0",
     "through": "^2.3.4"
   },


### PR DESCRIPTION
Newer versions of babel-istanbul use babel 6 instead of babel 5.